### PR TITLE
Explicitly add implicit relationships

### DIFF
--- a/structurizr/Program.cs
+++ b/structurizr/Program.cs
@@ -25,6 +25,9 @@ namespace structurizr
             Person user = model.AddPerson("User", "A user of my software system.");
             SoftwareSystem softwareSystem = model.AddSoftwareSystem("Software System", "My software system.");
             user.Uses(softwareSystem, "Uses");
+            
+            // add implicit relationships; this is enabled by default on the DSL, but not with the .NET library (for all options see https://github.com/structurizr/dotnet/blob/master/docs/implied-relationships.md)
+            model.AddImplicitRelationships();
 
             // define some views (the diagrams you would like to see)
             ViewSet views = workspace.Views;


### PR DESCRIPTION
Add implicit relationships to the quickstart - might cause confusion as this is enabled by default on the DSL but not in the .net library, which leads to different results, ref https://github.com/structurizr/dotnet/issues/97